### PR TITLE
Make Xcode project, add compatibility UUIDs for versions 12.4, 12.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ iOS DeviceSupport
 UserData
 watchOS DeviceSupport
 Products
+xcuserdata/

--- a/Plug-ins/Rust.ideplugin/Contents/Info.plist
+++ b/Plug-ins/Rust.ideplugin/Contents/Info.plist
@@ -48,6 +48,8 @@
 		<string>6C8909A0-F208-4C21-9224-504F9A70056E</string>
 		<string>DF12405B-55B4-4E00-8029-6AEFA7DBAD0F</string>
 		<string>3928AC50-EA32-404F-9CAF-49710A35483C</string>
+		<string>2F1A5FFF-BFEB-4498-B2AC-1296A7454F81</string>
+		<string>0D0B4174-3D1B-40F6-8E3E-FFFEB962F788</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>

--- a/rust-xcode-plugin.xcodeproj/project.pbxproj
+++ b/rust-xcode-plugin.xcodeproj/project.pbxproj
@@ -1,0 +1,81 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXFileReference section */
+		41BE404825CB090D00B50436 /* Specifications */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Specifications; sourceTree = "<group>"; };
+		41BE404925CB090D00B50436 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		41BE404A25CB090D00B50436 /* Plug-ins */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Plug-ins"; sourceTree = "<group>"; };
+		41BE404B25CB090D00B50436 /* setup.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = setup.sh; sourceTree = "<group>"; };
+		41BE404C25CB090D00B50436 /* Xcode.SourceCodeLanguage.Rust.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Xcode.SourceCodeLanguage.Rust.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		41BE404125CB08D200B50436 = {
+			isa = PBXGroup;
+			children = (
+				41BE404A25CB090D00B50436 /* Plug-ins */,
+				41BE404925CB090D00B50436 /* README.md */,
+				41BE404B25CB090D00B50436 /* setup.sh */,
+				41BE404825CB090D00B50436 /* Specifications */,
+				41BE404C25CB090D00B50436 /* Xcode.SourceCodeLanguage.Rust.plist */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+		41BE404225CB08D200B50436 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1250;
+			};
+			buildConfigurationList = 41BE404525CB08D200B50436 /* Build configuration list for PBXProject "rust-xcode-plugin" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 41BE404125CB08D200B50436;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+			);
+		};
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+		41BE404625CB08D200B50436 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		41BE404725CB08D200B50436 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		41BE404525CB08D200B50436 /* Build configuration list for PBXProject "rust-xcode-plugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41BE404625CB08D200B50436 /* Debug */,
+				41BE404725CB08D200B50436 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 41BE404225CB08D200B50436 /* Project object */;
+}

--- a/rust-xcode-plugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/rust-xcode-plugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/rust-xcode-plugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/rust-xcode-plugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Add Xcode compatibility UUIDs for versions 12.4, 12.5.
Make Xcode project.
Xcode editor provides xclangspecs for xclangspec and other plugin file types - no reason to not use it.