### PR TITLE
add UUID for Xcode 12.5 (12E262)

### DIFF
--- a/Plug-ins/Rust.ideplugin/Contents/Info.plist
+++ b/Plug-ins/Rust.ideplugin/Contents/Info.plist
@@ -50,6 +50,7 @@
 		<string>3928AC50-EA32-404F-9CAF-49710A35483C</string>
 		<string>2F1A5FFF-BFEB-4498-B2AC-1296A7454F81</string>
 		<string>0D0B4174-3D1B-40F6-8E3E-FFFEB962F788</string>
+		<string>F56A1938-53DE-493D-9D64-87EE6C415E4D</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
This branch adds the UUID for the Xcode version 12.5 (12E262) released on April 26, 2021.

```sh
> defaults read /Applications/Xcode.app/Contents/Info DVTPlugInCompatibilityUUID
F56A1938-53DE-493D-9D64-87EE6C415E4D
```