### PR TITLE
suggest running setup.sh as root for App Store-installed Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can check your UUID with this command:
 ```sh
 $ defaults read /Applications/Xcode.app/Contents/Info DVTPlugInCompatibilityUUID
 ```
-Once the UUID is added, execute the `setup.sh` script
+Once the UUID is added, execute the `setup.sh` script. If /Applications/Xcode.app is installed via the App Store, then you'll need to run the script as root (for example, via `sudo setup.sh`) to successfully install the language specifications and metadata files.
 
 You may have to quit and reopen Xcode once or twice and click the `Load Bundle` button in a popup that should appear automatically.
 

--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,13 @@ spec_dir="${xcode_path}/SharedFrameworks/SourceModel.framework/Versions/A/Resour
 
 # Copy the language specification to the specs directory
 cp Specifications/Rust.xclangspec $spec_dir
+
+result=$?
+if [ $result -ne 0 ]; then
+    echo "Error copying Rust.xclangspec; do you need to run this script as root?"
+    exit $result
+fi
+
 #cp Specifications/Rust.xcspec $spec_dir
 
 # Get language metadata directory
@@ -28,6 +35,12 @@ metadata_dir="${xcode_path}/SharedFrameworks/SourceModel.framework/Versions/A/Re
 
 # Copy the source code language plist to the metadata directory
 cp Xcode.SourceCodeLanguage.Rust.plist $metadata_dir
+
+result=$?
+if [ $result -ne 0 ]; then
+    echo "Error copying Xcode.SourceCodeLanguage.Rust.plist; do you need to run this script as root?"
+    exit $result
+fi
 
 defaults read ${xcode_path}/Info DVTPlugInCompatibilityUUID
 


### PR DESCRIPTION
The App Store installs /Applications/Xcode.app as root/wheel:

>\> ll -d /Applications/Xcode.app                                                                                      
>
>drwxr-xr-x@ 3 root  wheel    96B May 17 07:29 /Applications/Xcode.app
>
>\> ll -d /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications      
>
>drwxr-xr-x  52 root  wheel   1.6K May 20 09:10 /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
>
>\> ll -d /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata       
>
>drwxr-xr-x  58 root  wheel   1.8K May 20 09:10 /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata

Which prevents copying the language specification and metadata files when running setup.sh as a regular user:

>\> ./setup.sh                  
>…
>\+ cp Specifications/Rust.xclangspec /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
>cp: /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications/Rust.xclangspec: Permission denied
>…
>\+ cp Xcode.SourceCodeLanguage.Rust.plist /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
>cp: /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata/Xcode.SourceCodeLanguage.Rust.plist: Permission denied

This branch adds a note to the readme that you may have to run setup.sh as root. It also suggests that solution in the output of setup.sh itself if the cp commands fail.
