### PR TITLE
Added UUID for Xcode 14.1.0

### DIFF
--- a/Plug-ins/Rust.ideplugin/Contents/Info.plist
+++ b/Plug-ins/Rust.ideplugin/Contents/Info.plist
@@ -54,6 +54,7 @@
 		<string>8BAA96B4-5225-471B-B124-D32A349B8106</string>
 		<string>7A3A18B7-4C08-46F0-A96A-AB686D315DF0</string>
 		<string>EFD92DF8-D0A2-4C92-B6E3-9B3CD7E8DC19</string>
+		<string>B8A1C62D-289E-476A-B0CD-B16ADBDD8395</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
A simple pull request that adds the extension UUID for Xcode 14.1.0.